### PR TITLE
Use github actions to run preprocessing job in sciserver (Closes #13)

### DIFF
--- a/.github/workflows/job-submit-action.yml
+++ b/.github/workflows/job-submit-action.yml
@@ -3,9 +3,6 @@ name: Submit Job to Sciserver Compute
 on:
   schedule:
     - cron: 0 */12 * * *
-  push:
-    branches:
-      - 13-submit-job-action
 
 jobs:
   submit:
@@ -42,4 +39,4 @@ jobs:
           SCISERVER_USERNAME: ${{ secrets.SCISERVER_USERNAME }}
           SCISERVER_PASSWORD: ${{ secrets.SCISERVER_PASSWORD }}
         run: |
-          cd preprocessing && python3 submit_preprocessing_job.py
+          cd preprocessing && python3 submit_preprocessing_job.py -J "Large Jobs Domain"

--- a/.github/workflows/job-submit-action.yml
+++ b/.github/workflows/job-submit-action.yml
@@ -4,8 +4,9 @@ on:
   schedule:
     - cron: 0 */12 * * *
   push:
-    - branches:
-        - 13-submit-job-action
+    branches:
+      - 13-submit-job-action
+
   jobs:
     submit:
       runs-on: ubuntu-latest

--- a/.github/workflows/job-submit-action.yml
+++ b/.github/workflows/job-submit-action.yml
@@ -1,0 +1,44 @@
+name: Submit Job to Sciserver Compute
+
+on:
+  schedule:
+    - cron: 0 */12 * * *
+  push:
+    - branches:
+        - 13-submit-job-action
+  jobs:
+    submit:
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: checkout
+          uses: actions/checkout@v2
+
+        - name: Download csv for galaxy metadata
+          id: download_csv
+          run: |
+            wget https://www.dropbox.com/s/w68xoucr6jtp8bi/SDSS_DR12.csv?dl=0 -O preprocessing/data/SDSS_DR12.csv
+
+        - name: Setup Python
+          id: setup_python
+          uses: actions/setup-python@v1
+          with:
+            python-version: '3.7'
+
+        - name: Install Requirements
+          id: install_requirements
+          run: |
+            pip3 install -r requirements.txt
+            git clone https://github.com/sciserver/SciScript-Python.git \
+            	&& cd SciScript-Python \
+            	&& git checkout sciserver-v2.0.13 \
+            	&& cd py3 \
+            	&& python3 setup.py install
+
+        - name: Submit Job to SciServer-Compute
+          id: submit_job
+          env:
+            SCISERVER_USERNAME: ${{ secrets.SCISERVER_USERNAME }}
+            SCISERVER_PASSWORD: ${{ secrets.SCISERVER_PASSWORD }}
+          run: |
+            cd preprocessing && python3 submit_preprocessing_job.py

--- a/.github/workflows/job-submit-action.yml
+++ b/.github/workflows/job-submit-action.yml
@@ -7,39 +7,39 @@ on:
     branches:
       - 13-submit-job-action
 
-  jobs:
-    submit:
-      runs-on: ubuntu-latest
+jobs:
+  submit:
+    runs-on: ubuntu-latest
 
-      steps:
-        - name: checkout
-          uses: actions/checkout@v2
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
 
-        - name: Download csv for galaxy metadata
-          id: download_csv
-          run: |
-            wget https://www.dropbox.com/s/w68xoucr6jtp8bi/SDSS_DR12.csv?dl=0 -O preprocessing/data/SDSS_DR12.csv
+      - name: Download csv for galaxy metadata
+        id: download_csv
+        run: |
+          wget https://www.dropbox.com/s/w68xoucr6jtp8bi/SDSS_DR12.csv?dl=0 -O preprocessing/data/SDSS_DR12.csv
 
-        - name: Setup Python
-          id: setup_python
-          uses: actions/setup-python@v1
-          with:
-            python-version: '3.7'
+      - name: Setup Python
+        id: setup_python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
 
-        - name: Install Requirements
-          id: install_requirements
-          run: |
-            pip3 install -r requirements.txt
-            git clone https://github.com/sciserver/SciScript-Python.git \
-            	&& cd SciScript-Python \
-            	&& git checkout sciserver-v2.0.13 \
-            	&& cd py3 \
-            	&& python3 setup.py install
+      - name: Install Requirements
+        id: install_requirements
+        run: |
+          pip3 install -r requirements.txt
+          git clone https://github.com/sciserver/SciScript-Python.git \
+              && cd SciScript-Python \
+              && git checkout sciserver-v2.0.13 \
+              && cd py3 \
+              && python3 setup.py install
 
-        - name: Submit Job to SciServer-Compute
-          id: submit_job
-          env:
-            SCISERVER_USERNAME: ${{ secrets.SCISERVER_USERNAME }}
-            SCISERVER_PASSWORD: ${{ secrets.SCISERVER_PASSWORD }}
-          run: |
-            cd preprocessing && python3 submit_preprocessing_job.py
+      - name: Submit Job to SciServer-Compute
+        id: submit_job
+        env:
+          SCISERVER_USERNAME: ${{ secrets.SCISERVER_USERNAME }}
+          SCISERVER_PASSWORD: ${{ secrets.SCISERVER_PASSWORD }}
+        run: |
+          cd preprocessing && python3 submit_preprocessing_job.py

--- a/preprocessing/preprocess.sh
+++ b/preprocessing/preprocess.sh
@@ -12,5 +12,5 @@ cd ..
 cd ..
 export LC_ALL=en_US.utf-8
 export LANG=en_US.utf-8
-python3 sdss/preprocess.py data/SDSS_DR12.csv -u utimalsina -C 500 -N 100000 -O 64 --checkpoint-dir ckpts --num-processes=32 --volume-name=AstroResearch
+python3 sdss/preprocess.py data/SDSS_DR12.csv -u utimalsina -C 10 -N 100 -O 64 --checkpoint-dir ckpts --num-processes=32 --volume-name=AstroResearch
 cd ..

--- a/preprocessing/preprocess.sh
+++ b/preprocessing/preprocess.sh
@@ -12,5 +12,5 @@ cd ..
 cd ..
 export LC_ALL=en_US.utf-8
 export LANG=en_US.utf-8
-python3 sdss/preprocess.py data/SDSS_DR12.csv -u utimalsina -C 10 -N 100 -O 64 --checkpoint-dir ckpts --num-processes=32 --volume-name=AstroResearch
+python3 sdss/preprocess.py data/SDSS_DR12.csv -u utimalsina -C 500 -N 100000 -O 64 --checkpoint-dir ckpts --num-processes=32 --volume-name=AstroResearch
 cd ..


### PR DESCRIPTION
Instead of every 10 hours, a better idea is to run the job every 12 hours(two times a day).

To Dos for this PR:
- [x] Remove Branch Reference (done in c6d3210)
- [x] Set Jobs Domain to `Large Jobs Domain` in `.github/workflows/job-submit-action.yml` (done in c6d3210)

At this point, the job is running in `sciserver-compute` from github.
![image](https://user-images.githubusercontent.com/11476842/79826426-4c191500-8361-11ea-906f-93954c3dbcc3.png)
