### PR TITLE
Change pickling logic to handle MemoryError (Closes #31)

### DIFF
--- a/preprocessing/sdss/sdss_utils.py
+++ b/preprocessing/sdss/sdss_utils.py
@@ -7,3 +7,9 @@ def get_guid(rows, col_name='specObjID'):
     for idx, row in rows.iterrows():
         str_cols += str(row[col_name])
     return sha1(str_cols.encode('utf-8')).hexdigest()
+
+
+def get_hash(iterable):
+    """Return the sha1 hash of iterable of strings"""
+    combined_str = ''.join(iterable)
+    return sha1(combined_str.encode('utf-8')).hexdigest()

--- a/preprocessing/sdss/test_checkpoint_objects.py
+++ b/preprocessing/sdss/test_checkpoint_objects.py
@@ -5,65 +5,55 @@ from datetime import datetime
 
 import numpy as np
 
-from preprocessing.sdss.checkpoint_objects import CheckPoint, RedShiftCheckPointObject
+from preprocessing.sdss.checkpoint_objects import CheckPointer, RedShiftCheckPointObject
 
 
 class TestCheckpoint(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ckpt_object = CheckPoint(os.getcwd(), RedShiftCheckPointObject, guid='ckptObject')
         kwargs = [{
-            'key': i,
+            'key': str(i),
             'np_array': np.random.rand(64, 64, 5),
             'redshift': random.random(),
             'galaxy_meta': {'name': 'this is my name'},
             'image': 'path/to/image',
             'timestamp': datetime.now()
         } for i in range(5)]
-        TestCheckpoint.ckpt_object.save_checkpoint(kwargs, overwrite=True)
 
-    def test_meta_objects(self):
-        restored = CheckPoint.from_checkpoint(os.getcwd(), 'ckptObject')
-        for meta_object in restored.meta_objects.values():
-            assert type(meta_object) == RedShiftCheckPointObject
-            assert isinstance(meta_object.key, int)
-            assert isinstance(meta_object.np_array, np.ndarray)
-            assert isinstance(meta_object.galaxy_meta, dict)
-            assert isinstance(meta_object.image, str)
-            assert isinstance(meta_object.timestamp, datetime)
+        cls.checkpointer = CheckPointer(
+            ckpt_dir='ckpt',
+            guid='ckptGUID',
+            overwrite=True,
+            metaclass=RedShiftCheckPointObject,
+            meta_objects=kwargs
+        )
+        cls.last_modified = cls.checkpointer.last_modified
 
-    def test_checkpoint_exists(self):
-        restored = CheckPoint.get_object_set(os.getcwd(), 'ckptObject')
-        assert 0 in restored
-        assert 1 in restored
-        assert 2 in restored
-        assert 3 in restored
-        assert 4 in restored
-
-    def test_add_objects(self):
-        restored = CheckPoint.from_checkpoint(os.getcwd(), 'ckptObject')
-        assert len(restored.meta_objects) == 5
+    def test_add_objects_with_same_keys(self):
         kwargs = [{
-            'key': i,
+            'key': str(i),
             'np_array': np.random.rand(64, 64, 5),
             'redshift': random.random(),
             'galaxy_meta': {'name': 'this is my name'},
             'image': 'path/to/image',
             'timestamp': datetime.now()
         } for i in range(4, 10)]
-        TestCheckpoint.ckpt_object.save_checkpoint(kwargs, 'ckptObject')
-        restored_set = CheckPoint.get_object_set(os.getcwd(), 'ckptObject')
-        assert len(restored_set) == 10
+        TestCheckpoint.checkpointer.save_objects(kwargs)
 
-    def test_restore_checkpoint(self):
-        restored = CheckPoint.from_checkpoint(os.getcwd(), 'ckptObject')
-        assert [isinstance(meta_obj, restored.metaclass) for meta_obj in restored.meta_objects.values()] \
-            == [True] * len(restored.meta_objects)
+    def test_last_modified(self):
+        assert TestCheckpoint.checkpointer.last_modified != TestCheckpoint.last_modified
 
-    @classmethod
-    def tearDownClass(cls):
-        CheckPoint.remove_ckpt(os.getcwd(), 'ckptObject')
+    def test_get_specific_object(self):
+        assert TestCheckpoint.checkpointer.get_specific_object('9').key == '9'
 
+    def test_get_all_objects_info(self):
+        assert len(TestCheckpoint.checkpointer.return_all_objects_info()) == 2
+
+    def test_file_not_found(self):
+        objects = TestCheckpoint.checkpointer.return_objects_for('f2231d2871e690a2995704f7a297bd7bc64be720.pkl')
+        assert len(objects) == 5
+        assert type(objects) == dict
+        assert [isinstance(a_member, RedShiftCheckPointObject) for a_member in objects.values()]
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- [x] Change pickling logic to save several pickle files for a single checkpoint.
- [ ] Use modified checkpointing in the preprocess piepeline (ToDo). 